### PR TITLE
Update customStash.js to fix progressiveHook bug when `args[0].Item` is undefined

### DIFF
--- a/packages/utils/AssetManager/customStash.js
+++ b/packages/utils/AssetManager/customStash.js
@@ -94,8 +94,14 @@ export function enableCustomAssets() {
     ModManager.progressiveHook("InventoryAvailable").inside("WardrobeFastLoad").override(overrideAvailable);
 
     ModManager.progressiveHook("CraftingValidate").inject((args, next) => {
-        const asset = CraftingAssets[args[0].Item]?.[0];
-        if (asset && isInListCustomAsset(asset.Group.Name, asset.Name)) args[3] = false;
+        try {
+            if (args[0].Item != undefined) {
+                const asset = CraftingAssets[args[0].Item]?.[0];
+                if (asset && isInListCustomAsset(asset.Group.Name, asset.Name)) args[3] = false;
+            }
+        } catch (error) {
+            console.log(`${error} at -mod/packages/utils/AssetManager/customStash.js at ModManager.progressiveHook("CraftingValidate")`);
+        }
     });
 
     const pInventory = ModManager.randomGlobalFunction("CraftingInventory", () => {


### PR DESCRIPTION
I submitted this as an issue as well, but thought I could go ahead and code a fix. This should stop it from tossing errors if `args[0].Item` is undefined.