### PR TITLE
MAINT: Adapt to the R111 dialog `item` and `activities` menu rework

### DIFF
--- a/packages/mod/src/components/汉堡标志.js
+++ b/packages/mod/src/components/汉堡标志.js
@@ -25,27 +25,41 @@ FhZ6IIeuA4OENTMzowCWlpaMrVpt8gL6EJROpwGYmpoyJfHc3Fxrfyv0QP4D/SuQTlQPpN30FwcY
 PMrnpTehAAAAAElFTkSuQmCC`;
 
 export default function () {
-    const iconSize = 50;
-    const margin = 5;
-    const hoverText = ModInfo.name;
+    if (GameVersion === "R110") {
+        const iconSize = 50;
+        const margin = 5;
+        const hoverText = ModInfo.name;
 
-    const func = (args, next) => {
-        const [x, y, asset, { Width, Height }] = args;
-        if (AssetManager.assetIsCustomed(asset)) {
-            const iconX = x + (Width || DrawAssetPreviewDefaultWidth) - iconSize - margin;
-            const iconY = y + (Height || DrawAssetPreviewDefaultHeight) - iconSize - margin - 40;
+        const func = (args, next) => {
+            const [x, y, asset, { Width, Height }] = args;
+            if (AssetManager.assetIsCustomed(asset)) {
+                const iconX = x + (Width || DrawAssetPreviewDefaultWidth) - iconSize - margin;
+                const iconY = y + (Height || DrawAssetPreviewDefaultHeight) - iconSize - margin - 40;
 
-            DrawImageResize(hanburgerIcon, iconX, iconY, iconSize, iconSize);
-            if (MouseIn(iconX, iconY, iconSize * 0.9, iconSize * 0.9)) {
-                DrawHoverElements.push(() => DrawButtonHover(iconX, iconY, 100, 65, hoverText));
+                DrawImageResize(hanburgerIcon, iconX, iconY, iconSize, iconSize);
+                if (MouseIn(iconX, iconY, iconSize * 0.9, iconSize * 0.9)) {
+                    DrawHoverElements.push(() => DrawButtonHover(iconX, iconY, 100, 65, hoverText));
+                }
             }
-        }
-    };
+        };
 
-    ModManager.progressiveHook("DrawAssetPreview", 1).inside("DialogDrawItemMenu").next().inject(func);
-    ModManager.progressiveHook("DrawAssetPreview", 1)
-        .inside("AppearanceRun")
-        .next()
-        .when(() => CharacterAppearanceMode == "Cloth")
-        .inject(func);
+        ModManager.progressiveHook("DrawAssetPreview", 1).inside("DialogDrawItemMenu").next().inject(func);
+        ModManager.progressiveHook("DrawAssetPreview", 1)
+            .inside("AppearanceRun")
+            .next()
+            .when(() => CharacterAppearanceMode == "Cloth")
+            .inject(func);
+    } else { // R111
+        ModManager.hookFunction("ElementButton.CreateForAsset", 0, (args, next) => {
+            const asset = "Asset" in args[1] ? args[1].Asset : args[1];
+            if (AssetManager.assetIsCustomed(asset)) {
+                args[4] ??= {};
+                args[4].icons = [
+                    ...(args[4].icons ?? []),
+                    { iconSrc: hanburgerIcon, tooltipText: ModInfo.name },
+                ];
+            }
+            return next(args);
+        });
+    }
 }

--- a/packages/mod2/src/components/标志.js
+++ b/packages/mod2/src/components/标志.js
@@ -25,23 +25,36 @@ FhZ6IIeuA4OENTMzowCWlpaMrVpt8gL6EJROpwGYmpoyJfHc3Fxrfyv0QP4D/SuQTlQPpN30FwcY
 PMrnpTehAAAAAElFTkSuQmCC`;
 
 export default function () {
-    const iconSize = 50;
-    const margin = 5;
-    const hoverText = ModInfo.name;
+    if (GameVersion === "R110") {
+        const iconSize = 50;
+        const margin = 5;
+        const hoverText = ModInfo.name;
 
-    const gfunc = ModManager.randomGlobalFunction("DrawAct", (x, y, w, h, act) => {
-        if (ActivityManager.activityIsCustom(act)) {
-            const iconX = x + (w || DrawAssetPreviewDefaultWidth) - iconSize - margin;
-            const iconY = y + (h || DrawAssetPreviewDefaultHeight) - iconSize - margin - 40;
+        const gfunc = ModManager.randomGlobalFunction("DrawAct", (x, y, w, h, act) => {
+            if (ActivityManager.activityIsCustom(act)) {
+                const iconX = x + (w || DrawAssetPreviewDefaultWidth) - iconSize - margin;
+                const iconY = y + (h || DrawAssetPreviewDefaultHeight) - iconSize - margin - 40;
 
-            DrawImageResize(hanburgerIcon, iconX, iconY, iconSize, iconSize);
-            if (MouseIn(iconX, iconY, iconSize * 0.9, iconSize * 0.9)) {
-                DrawHoverElements.push(() => DrawButtonHover(iconX, iconY, 100, 65, hoverText));
+                DrawImageResize(hanburgerIcon, iconX, iconY, iconSize, iconSize);
+                if (MouseIn(iconX, iconY, iconSize * 0.9, iconSize * 0.9)) {
+                    DrawHoverElements.push(() => DrawButtonHover(iconX, iconY, 100, 65, hoverText));
+                }
             }
-        }
-    });
+        });
 
-    ModManager.patchFunction("DialogDrawActivityMenu", {
-        "return false;": `${gfunc}(x,y,width,height,Act.Name); return false;`,
-    });
+        ModManager.patchFunction("DialogDrawActivityMenu", {
+            "return false;": `${gfunc}(x,y,width,height,Act.Name); return false;`,
+        });
+    } else { // R111
+        ModManager.hookFunction("ElementButton.CreateForActivity", 0, (args, next) => {
+            if (ActivityManager.activityIsCustom(args[1].Activity.Name)) {
+                args[4] ??= {};
+                args[4].icons = [
+                    ...(args[4].icons ?? []),
+                    { iconSrc: hanburgerIcon, tooltipText: ModInfo.name },
+                ];
+            }
+            return next(args);
+        });
+    }
 }

--- a/packages/utils/ActivityManager/image.js
+++ b/packages/utils/ActivityManager/image.js
@@ -40,8 +40,22 @@ export function setupImgMapping() {
         return src;
     };
 
-    ["DrawImageEx", "GLDrawImage", "DrawGetImage"].forEach(
-        (/** @type {"DrawImageEx" |"GLDrawImage"| "DrawGetImage"}*/ fn) =>
-            ModManager.progressiveHook(fn, 9).inject((args, next) => (args[0] = mapImgSrc(args[0])))
-    );
+    if (GameVersion === "R110") {
+        ["DrawImageEx", "GLDrawImage", "DrawGetImage"].forEach(
+            (/** @type {"DrawImageEx" |"GLDrawImage"| "DrawGetImage"}*/ fn) =>
+                ModManager.progressiveHook(fn, 9).inject((args, next) => (args[0] = mapImgSrc(args[0])))
+        );
+    } else { // R111
+        ModManager.hookFunction("ElementButton.CreateForActivity", 0, (args, next) => {
+            const button = next(args);
+            const img = button.querySelector("img.button-image");
+            if (img?.src) {
+                const idx = img.src.indexOf("Assets/");
+                if (idx !== -1) {
+                    img.src = mapImgSrc(decodeURI(img.src.slice(idx)));
+                }
+            }
+            return button;
+        });
+    }
 }

--- a/packages/utils/AssetManager/imgMapping.js
+++ b/packages/utils/AssetManager/imgMapping.js
@@ -68,25 +68,39 @@ export function setupImgMapping() {
         return src;
     };
 
-    ["DrawImageEx", "DrawImageResize", "GLDrawImage", "DrawGetImage"].forEach(
-        (/** @type {"DrawImageEx" | "GLDrawImage" | "DrawGetImage"}*/ fn) => {
-            ModManager.progressiveHook(fn, 0).inject((args, next) => (args[0] = mapImgSrc(args[0])));
-        }
-    );
+    if (GameVersion === "R110") {
+        ["DrawImageEx", "DrawImageResize", "GLDrawImage", "DrawGetImage"].forEach(
+            (/** @type {"DrawImageEx" | "GLDrawImage" | "DrawGetImage"}*/ fn) => {
+                ModManager.progressiveHook(fn, 0).inject((args, next) => (args[0] = mapImgSrc(args[0])));
+            }
+        );
 
-    (async () => {
-        await sleepUntil(() => window["CraftingElements"] !== undefined);
+        (async () => {
+            await sleepUntil(() => window["CraftingElements"] !== undefined);
 
-        ModManager.hookFunction("CraftingElements._RadioButton", 5, (args, next) => {
-            const ret = next(args);
-            const img = ret.querySelector("img");
+            ModManager.hookFunction("CraftingElements._RadioButton", 5, (args, next) => {
+                const ret = next(args);
+                const img = ret.querySelector("img");
+                if (img?.src) {
+                    const idx = img.src.indexOf("Assets/");
+                    if (idx !== -1) {
+                        img.src = mapImgSrc(decodeURI(img.src.slice(idx)));
+                    }
+                }
+                return ret;
+            });
+        })();
+    } else { // R111
+        ModManager.hookFunction("ElementButton.CreateForAsset", 0, (args, next) => {
+            const button = next(args);
+            const img = button.querySelector("img.button-image");
             if (img?.src) {
                 const idx = img.src.indexOf("Assets/");
                 if (idx !== -1) {
                     img.src = mapImgSrc(decodeURI(img.src.slice(idx)));
                 }
             }
-            return ret;
+            return button;
         });
-    })();
+    }
 }

--- a/packages/utils/AssetManager/imgMapping.js
+++ b/packages/utils/AssetManager/imgMapping.js
@@ -68,13 +68,13 @@ export function setupImgMapping() {
         return src;
     };
 
-    if (GameVersion === "R110") {
-        ["DrawImageEx", "DrawImageResize", "GLDrawImage", "DrawGetImage"].forEach(
-            (/** @type {"DrawImageEx" | "GLDrawImage" | "DrawGetImage"}*/ fn) => {
-                ModManager.progressiveHook(fn, 0).inject((args, next) => (args[0] = mapImgSrc(args[0])));
-            }
-        );
+    ["DrawImageEx", "DrawImageResize", "GLDrawImage", "DrawGetImage"].forEach(
+        (/** @type {"DrawImageEx" | "GLDrawImage" | "DrawGetImage"}*/ fn) => {
+            ModManager.progressiveHook(fn, 0).inject((args, next) => (args[0] = mapImgSrc(args[0])));
+        }
+    );
 
+    if (GameVersion === "R110") {
         (async () => {
             await sleepUntil(() => window["CraftingElements"] !== undefined);
 
@@ -91,6 +91,8 @@ export function setupImgMapping() {
             });
         })();
     } else { // R111
+        await sleepUntil(() => window["ElementButton"] !== undefined);
+
         ModManager.hookFunction("ElementButton.CreateForAsset", 0, (args, next) => {
             const button = next(args);
             const img = button.querySelector("img.button-image");


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5278](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5278)

Above-mentioned PR overhauls the UI of a number of dialog menu modes (including the `item` and `activities` mode) for R111, switching from a canvas- to DOM-based UI. Consequently, custom items and activities will now have to hook into, respectively, `ElementButton.CreateForAsset()` and `ElementButton.CreateForActivity()` in order to set their custom button images, a change which is thus introduced herein.

Includes changes both suitable for the beta-period and full R111 release.
