### PR TITLE
MAINT: R111Beta2 - Pass along an icon name when constructing custom button icons

### DIFF
--- a/packages/mod/src/components/汉堡标志.js
+++ b/packages/mod/src/components/汉堡标志.js
@@ -56,7 +56,7 @@ export default function () {
             if (AssetManager.assetIsCustomed(asset)) {
                 _args[4] = {
                     ..._args[4],
-                    icons: [...(_args[4].icons ?? []), { iconSrc: hanburgerIcon, tooltipText: ModInfo.name }],
+                    icons: [...(_args[4].icons ?? []), { iconSrc: hanburgerIcon, tooltipText: ModInfo.name, name: ModInfo.name }],
                 };
             }
             return next(args);

--- a/packages/mod2/src/components/标志.js
+++ b/packages/mod2/src/components/标志.js
@@ -51,7 +51,7 @@ export default function () {
             if (ActivityManager.activityIsCustom(_args[1].Activity.Name)) {
                 _args[4] = {
                     ..._args[4],
-                    icons: [...(_args[4].icons ?? []), { iconSrc: hanburgerIcon, tooltipText: ModInfo.name }],
+                    icons: [...(_args[4].icons ?? []), { iconSrc: hanburgerIcon, tooltipText: ModInfo.name, name: ModInfo.name }],
                 };
             }
             return next(args);


### PR DESCRIPTION
Follow up on https://github.com/emdsa2/-mod/pull/48

Adapts to a [BondageProjects/Bondage-College#5315](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5315) change which added the new `name` field for when specifying custom icons.